### PR TITLE
Tool New feature

### DIFF
--- a/server/wsConnect.js
+++ b/server/wsConnect.js
@@ -327,23 +327,24 @@ module.exports = {
             requests.map(async (request) => {
               if (request.status !== "solved") {
                 // console.log("request before", request);
-                request.requestBody = request.requestBody.filter(
-                  (board) => board.board !== deletedName
-                );
+                if (request.requestBody.length === 0) {
+                  request.status = "cancel";
+                  // const user = await model.TeamModel.findOne({
+                  //   _id: request.borrower,
+                  // });
+                  // user.requests = user.requests.filter(
+                  //   (id) => id !== request._id
+                  // );
+                  // await user.save();
+                  // await model.RequestModel.deleteOne({
+                  //   _id: request._id,
+                  // });
+                } else {
+                  request.requestBody = request.requestBody.filter(
+                    (board) => board.board !== deletedName
+                  );
+                }
                 // console.log("request after", request);
-              }
-              if (request.requestBody.length === 0) {
-                request.status = "cancel";
-                // const user = await model.TeamModel.findOne({
-                //   _id: request.borrower,
-                // });
-                // user.requests = user.requests.filter(
-                //   (id) => id !== request._id
-                // );
-                // await user.save();
-                // await model.RequestModel.deleteOne({
-                //   _id: request._id,
-                // });
               }
               await request.save();
             })

--- a/server/wsConnect.js
+++ b/server/wsConnect.js
@@ -603,6 +603,14 @@ module.exports = {
         //sendStatus(["success", "Reset successfully"], ws);
         break;
       }
+      case "BROADCASTANOUNCEMENT": {
+        const { task, msg, authority } = payload;
+        broadcastAuth(authority ?? 0, [
+          "ADMINANOUNCEMENT",
+          { task, msg, authority },
+        ]);
+        break;
+      }
     }
   },
   onClose: (ws) => async () => {

--- a/server/wsConnect.js
+++ b/server/wsConnect.js
@@ -460,7 +460,7 @@ module.exports = {
           );
           broadcast({ id: newReq.borrower.teamID }, [
             "status",
-            ["success", "Request Ready!!"],
+            ["success", "Request Ready!!", 8640000],
           ]);
         }
         if (requestStatus === "solved") {
@@ -516,6 +516,12 @@ module.exports = {
             ["success", "Boards have taken!!"],
           ]);
         } // broadcast
+        if (requestStatus === "waiting") {
+          broadcast({ id: newReq.borrower.teamID }, [
+            "status",
+            ["success", "請確認是否領取", 8640000],
+          ]);
+        } // broadcast
         if (requestStatus === "denied") {
           broadcast({ id: newReq.borrower.teamID }, [
             "status",
@@ -527,7 +533,7 @@ module.exports = {
         if (requestStatus === "cancel") {
           changeBoardRemain(newReq);
         } // broadcast
-        sendStatus(["success", "Update successfully"], ws);
+        // sendStatus(["success", "Update successfully"], ws);
         break;
       }
       case "UPDATERETURN": {

--- a/server/wsConnect.js
+++ b/server/wsConnect.js
@@ -145,472 +145,528 @@ module.exports = {
     const { data } = byteString;
     const [task, payload] = JSON.parse(data);
     console.log(task, payload);
+    try {
+      switch (task) {
+        case "RESETDATABASE": {
+          console.log("Reseting...");
+          await model.BoardModel.deleteMany({});
+          await model.RequestModel.deleteMany({});
+          await model.TeamModel.updateMany(
+            {},
+            { $set: { myCards: new Map(), requests: [] } }
+          );
+          console.log("Database has been cleared.");
 
-    switch (task) {
-      case "RESETDATABASE": {
-        console.log("Reseting...");
-        await model.BoardModel.deleteMany({});
-        await model.RequestModel.deleteMany({});
-        await model.TeamModel.updateMany(
-          {},
-          { $set: { myCards: new Map(), requests: [] } }
-        );
-        console.log("Database has been cleared.");
+          const userData = await model.TeamModel.find({});
+          userData.map((user) => {
+            broadcast({ id: user.teamID }, ["GETUSER", user]);
+          });
+          broadcastPage("userProgress", ["AddBoard", []]);
+          broadcast({ authority: 1 }, ["GETBOARD", []]);
+          broadcast({ page: "requestStatus" }, ["UPDATEREQUEST", []]);
+          broadcast({ page: "requestStatus" }, ["UPDATERETURN", userData]);
+          console.log("All Change has been sent.");
 
-        const userData = await model.TeamModel.find({});
-        userData.map((user) => {
-          broadcast({ id: user.teamID }, ["GETUSER", user]);
-        });
-        broadcastPage("userProgress", ["AddBoard", []]);
-        broadcast({ authority: 1 }, ["GETBOARD", []]);
-        broadcast({ page: "requestStatus" }, ["UPDATEREQUEST", []]);
-        broadcast({ page: "requestStatus" }, ["UPDATERETURN", userData]);
-        console.log("All Change has been sent.");
-
-        break;
-      }
-      case "SUBSCRIBE": {
-        const { id, authority, page } = payload;
-        //userStatus & userProgress & adminBoardList
-        if (userPage[ws.box]) userPage[ws.box].delete(ws);
-        if (teamID[ws.id]) teamID[ws.id].delete(ws);
-        if (userAuth[ws.authority]) userAuth[ws.authority].delete(ws);
-
-        if (!userPage[page]) userPage[page] = new Set();
-        userPage[page].add(ws);
-        ws.box = page;
-        // // console.log("change page to " + ws.box);
-
-        if (!teamID[id]) teamID[id] = new Set();
-        teamID[id].add(ws);
-        ws.id = id;
-
-        if (!userAuth[authority]) userAuth[authority] = new Set();
-        userAuth[authority].add(ws);
-        ws.authority = authority;
-
-        // console.log(id, authority);
-        // console.log("change page to " + ws.box);
-        break;
-      }
-      case "DELETEREQUESTFROMUSER": {
-        let userData = await model.TeamModel.findOne({ teamID: payload[0] });
-
-        let newRequest = userData.requests;
-        const newR = newRequest.filter(
-          (re) => String(re._id) !== String(payload[1])
-        );
-        // // console.log("newR:", newR);
-        // // console.log("newRequest:", newRequest);
-        await model.TeamModel.updateOne(
-          { teamID: payload[0] },
-          { $set: { requests: newR } }
-        );
-        userData = await model.TeamModel.findOne({ teamID: payload[0] });
-        await userData.populate("requests").execPopulate();
-        await userData.save();
-        broadcast({ id: userData.teamID, authority: 0, page: "userStatus" }, [
-          "GETUSER",
-          userData,
-        ]);
-        break;
-      }
-      case "CANCELREQUEST": {
-        let userData = await model.TeamModel.findOne({ teamID: payload[0] });
-        await model.RequestModel.updateOne(
-          { _id: payload[1] },
-          { $set: { status: "cancel" } }
-        );
-        let request = await model.RequestModel.findById(payload[1]);
-        await changeBoardRemain(request);
-        await userData.populate("requests").execPopulate();
-        broadcast({ id: userData.teamID, authority: 0, page: "userStatus" }, [
-          "GETUSER",
-          userData,
-        ]);
-        broadcast({ id: userData.teamID, authority: 0, page: "userProgress" }, [
-          "GETUSER",
-          userData,
-        ]);
-        const requests = await model.RequestModel.find().populate(["borrower"]);
-        broadcast({ authority: 1, page: "requestStatus" }, [
-          "UPDATEREQUEST",
-          requests,
-        ]);
-        break;
-      }
-      case "GETUSER": {
-        let userData = await model.TeamModel.findOne({ teamID: payload });
-        console.log(userData, payload);
-        await userData.populate("requests").execPopulate();
-        sendData(["GETUSER", userData], ws);
-        // sendStatus(["success", "Get successfully"], ws);
-        break;
-      }
-      case "INITUSERCARD": {
-        const boards = await model.BoardModel.find({});
-        sendData(["INITUSERCARD", boards], ws);
-        // sendStatus(["success", "Get successfully"], ws);
-        break;
-      }
-      case "ADDBOARD": {
-        const newData = payload;
-        // console.log("AddBoard:", newData);
-        const existing = await model.BoardModel.find({
-          name: newData.name,
-        });
-        if (existing.length !== 0) {
-          sendStatus(["error", `${newData.name} already exist.`], ws);
           break;
         }
-        try {
-          const temp = await new model.BoardModel(payload).save();
-          const newBoard = await model.BoardModel.find({});
-          broadcastPage("adminBoardList", ["AddBoard", newBoard]);
-          broadcastPage("userProgress", ["AddBoard", newBoard]);
-          sendStatus(["success", "Add successfully"], ws);
-        } catch (e) {
-          throw new Error("Board DB save error: " + e);
-        }
-        break;
-      }
-      case "UPDATEBOARDS": {
-        const newData = payload;
-        try {
-          await Promise.all(
-            newData.map(
-              async (board) =>
-                await model.BoardModel.replaceOne(
-                  {
-                    name: board.name,
-                  },
-                  { ...board, remain: board.totalNum },
-                  { upsert: true }
-                )
-            )
-          );
-          sendStatus(["success", "Update successfully"], ws);
-          const boards = await model.BoardModel.find({});
-          sendData(["UpdateBoard", { status: "success", data: boards }], ws);
-          broadcastPage("userProgress", ["AddBoard", boards]);
-          broadcastPage("adminBoardList", ["AddBoard", boards]);
-        } catch (e) {
-          throw new Error("Board DB update error: " + e);
-        }
-        break;
-      }
-      case "DELETEBOARD": {
-        const newDataID = payload;
-        const existing = await model.BoardModel.deleteOne({
-          id: newDataID,
-        });
-        const boards = await model.BoardModel.find({});
-        broadcastPage("userProgress", ["AddBoard", boards]);
-        broadcast({ page: "adminBoardList" }, ["GETBOARD", boards]);
-        sendStatus(["success", "Delete successfully"], ws);
-        break;
-      }
-      case "GETBOARD": {
-        const boards = await model.BoardModel.find({});
-        // // console.log(boards);
-        sendData(["GETBOARD", boards], ws);
-        //sendStatus(["success", "Get successfully"], ws);
-        break;
-      }
-      case "GETREQUEST": {
-        //need populate
-        const requests = await model.RequestModel.find().populate(["borrower"]);
-        // await requests..execPopulate();
-        // // console.log(requests);
-        sendData(["GETREQUEST", requests], ws);
-        // sendStatus(["success", "Get successfully"], ws);
-        break;
-      }
-      case "REQUEST": {
-        let { group, requestBody } = payload;
-        let gp = await model.TeamModel.findOne({ teamID: group });
-        let count = await model.RequestModel.countDocuments({
-          borrower: gp,
-        });
-        let boardMissing = false;
-        let numNotSatisfy = false;
-        await Promise.all(
-          requestBody.map(async (board) => {
-            const myboard = await model.BoardModel.findOne({
-              name: board[0],
-            });
-            if (!myboard) {
-              // console.log("Board missing:", board, myboard);
-              boardMissing = true;
-              return;
-            }
-            if (myboard.remain - board[1] < 0) {
-              numNotSatisfy = true;
-            }
-          })
-        );
-        if (numNotSatisfy) {
-          sendData(
-            [
-              "USERPROGRESSSTATUS",
-              [
-                `Request Failed !`,
-                `Some Boards are not enough for your request . Please Reselect Again!`,
-              ],
-            ],
-            ws
-          );
+        case "SUBSCRIBE": {
+          const { id, authority, page } = payload;
+          //userStatus & userProgress & adminBoardList
+          if (userPage[ws.box]) userPage[ws.box].delete(ws);
+          if (teamID[ws.id]) teamID[ws.id].delete(ws);
+          if (userAuth[ws.authority]) userAuth[ws.authority].delete(ws);
+
+          if (!userPage[page]) userPage[page] = new Set();
+          userPage[page].add(ws);
+          ws.box = page;
+          // // console.log("change page to " + ws.box);
+
+          if (!teamID[id]) teamID[id] = new Set();
+          teamID[id].add(ws);
+          ws.id = id;
+
+          if (!userAuth[authority]) userAuth[authority] = new Set();
+          userAuth[authority].add(ws);
+          ws.authority = authority;
+
+          // console.log(id, authority);
+          // console.log("change page to " + ws.box);
           break;
         }
-        if (boardMissing) {
-          sendData(
-            [
-              "USERPROGRESSSTATUS",
-              [
-                `Request Failed !`,
-                `Some Boards Missing. Please Refresh Page Again!`,
-              ],
-            ],
-            ws
-          );
-          break;
-        }
-        let body = requestBody.map((e) => {
-          return { board: e[0], quantity: e[1] };
-        });
+        case "DELETEREQUESTFROMUSER": {
+          let userData = await model.TeamModel.findOne({ teamID: payload[0] });
 
-        const request = new model.RequestModel({
-          requestID: "Group" + group + "_request" + (count + 1),
-          borrower: gp,
-          sendingTime: new Date().getTime(),
-          status: "pending",
-          requestBody: body,
-        });
-        setTimeout(
-          () =>
-            requestExpired(
-              "Group" + group + "_request" + (count + 1),
-              "pending"
-            ),
-          15 * 60 * 1000
-        );
-        try {
-          await request.save();
-        } catch (e) {
-          // throw new Error("Request DB save error: " + e);
-          sendData(["USERPROGRESSSTATUS", [`Request Failed !`, `${e}`]], ws);
-        }
-        await model.TeamModel.updateMany(
-          { teamID: group },
-          { $push: { requests: request } }
-        );
-        const requests = await model.RequestModel.find().populate(["borrower"]);
-        // // console.log(requests);
-        await Promise.all(
-          request.requestBody.map(async (board) => {
-            const myboard = await model.BoardModel.updateOne(
-              {
-                name: board.board,
-              },
-              { $inc: { remain: -board.quantity } }
-            );
-            // myboard.remain -= board.quantity;
-          })
-        );
-        broadcastAuth(1, ["status", ["success", "New Request come in!"]]);
-        broadcast({ authority: 1, page: "requestStatus" }, [
-          "UPDATEREQUEST",
-          requests,
-        ]);
-        // sendStatus(["success", "Request successfully"], ws);
-        sendData(["USERPROGRESSSTATUS", [`Request successfully !`]], ws);
-        const boards = await model.BoardModel.find({});
-        broadcast({ page: "userProgress" }, ["INITUSERCARD", boards]);
-        broadcast({ page: "adminBoardList" }, ["GETBOARD", boards]);
-
-        let userData = await model.TeamModel.findOne({ teamID: group });
-        await userData.populate("requests").execPopulate();
-        broadcast({ id: group }, ["GETUSER", userData]);
-        break;
-      }
-      case "UPDATEREQ": {
-        const { requestID, requestStatus } = payload;
-        await model.RequestModel.updateOne(
-          { _id: requestID },
-          { $set: { status: requestStatus } }
-        );
-        const newReq = await model.RequestModel.findOne({
-          _id: requestID,
-        }).populate(["borrower"]);
-        // // console.log(newReq);
-
-        if (requestStatus === "ready") {
-          await model.RequestModel.updateOne(
-            { _id: requestID },
-            {
-              $set: {
-                status: requestStatus,
-                sendingTime: new Date().getTime(),
-              },
-            }
+          let newRequest = userData.requests;
+          const newR = newRequest.filter(
+            (re) => String(re._id) !== String(payload[1])
           );
-          setTimeout(
-            () => requestExpired(newReq.requestID, "ready"),
-            15 * 60 * 1000
+          // // console.log("newR:", newR);
+          // // console.log("newRequest:", newRequest);
+          await model.TeamModel.updateOne(
+            { teamID: payload[0] },
+            { $set: { requests: newR } }
           );
-          broadcast({ id: newReq.borrower.teamID }, [
-            "status",
-            ["success", "Request Ready!!", 8640000],
+          userData = await model.TeamModel.findOne({ teamID: payload[0] });
+          await userData.populate("requests").execPopulate();
+          await userData.save();
+          broadcast({ id: userData.teamID, authority: 0, page: "userStatus" }, [
+            "GETUSER",
+            userData,
           ]);
+          break;
         }
-        if (requestStatus === "solved") {
-          await updateMyCards(newReq.borrower.teamID, newReq.requestBody);
+        case "CANCELREQUEST": {
+          let userData = await model.TeamModel.findOne({ teamID: payload[0] });
+          await model.RequestModel.updateOne(
+            { _id: payload[1] },
+            { $set: { status: "cancel" } }
+          );
+          let request = await model.RequestModel.findById(payload[1]);
+          await changeBoardRemain(request);
+          await userData.populate("requests").execPopulate();
+          broadcast({ id: userData.teamID, authority: 0, page: "userStatus" }, [
+            "GETUSER",
+            userData,
+          ]);
+          broadcast(
+            { id: userData.teamID, authority: 0, page: "userProgress" },
+            ["GETUSER", userData]
+          );
+          const requests = await model.RequestModel.find().populate([
+            "borrower",
+          ]);
+          broadcast({ authority: 1, page: "requestStatus" }, [
+            "UPDATEREQUEST",
+            requests,
+          ]);
+          break;
+        }
+        case "GETUSER": {
+          let userData = await model.TeamModel.findOne({ teamID: payload });
+          console.log(userData, payload);
+          await userData.populate("requests").execPopulate();
+          sendData(["GETUSER", userData], ws);
+          // sendStatus(["success", "Get successfully"], ws);
+          break;
+        }
+        case "INITUSERCARD": {
+          const boards = await model.BoardModel.find({});
+          sendData(["INITUSERCARD", boards], ws);
+          // sendStatus(["success", "Get successfully"], ws);
+          break;
+        }
+        case "ADDBOARD": {
+          const newData = payload;
+          // console.log("AddBoard:", newData);
+          const existing = await model.BoardModel.find({
+            name: newData.name,
+          });
+          if (existing.length !== 0) {
+            sendStatus(["error", `${newData.name} already exist.`], ws);
+            break;
+          }
+          try {
+            const temp = await new model.BoardModel(payload).save();
+            const newBoard = await model.BoardModel.find({});
+            broadcastPage("adminBoardList", ["AddBoard", newBoard]);
+            broadcastPage("userProgress", ["AddBoard", newBoard]);
+            sendStatus(["success", "Add successfully"], ws);
+          } catch (e) {
+            throw new Error("Board DB save error: " + e);
+          }
+          break;
+        }
+        case "UPDATEBOARDS": {
+          const newData = payload;
+          try {
+            await Promise.all(
+              newData.map(
+                async (board) =>
+                  await model.BoardModel.replaceOne(
+                    {
+                      name: board.name,
+                    },
+                    { ...board, remain: board.totalNum },
+                    { upsert: true }
+                  )
+              )
+            );
+            sendStatus(["success", "Update successfully"], ws);
+            const boards = await model.BoardModel.find({});
+            sendData(["UpdateBoard", { status: "success", data: boards }], ws);
+            broadcastPage("userProgress", ["AddBoard", boards]);
+            broadcastPage("adminBoardList", ["AddBoard", boards]);
+          } catch (e) {
+            throw new Error("Board DB update error: " + e);
+          }
+          break;
+        }
+        case "DELETEBOARD": {
+          const newDataID = payload;
+          const existing = await model.BoardModel.findOne({
+            id: newDataID,
+          });
+          const deletedName = existing.name;
+          console.log(existing, deletedName);
+          await model.BoardModel.deleteOne({
+            id: newDataID,
+          });
+          const boards = await model.BoardModel.find({});
+          const users = await model.TeamModel.find({});
+          const requests = await model.RequestModel.find({});
           await Promise.all(
-            newReq.requestBody.map(async (board) => {
-              const myboard = await model.BoardModel.findOne({
-                name: board.board,
-              });
-              let found = false;
-              let newInvoice = myboard.invoice.map((item) => {
-                if (String(newReq.borrower._id) === String(item.group)) {
-                  found = true;
-                  return {
-                    group: item.group,
-                    number: item.number + board.quantity,
-                  };
-                } else {
-                  return item;
-                }
-              });
-              if (!found) {
-                newInvoice = [
-                  ...myboard.invoice,
-                  { group: newReq.borrower._id, number: board.quantity },
-                ];
-              }
-              // // console.log("newInvoice: ", board, newInvoice);
-              myboard.invoice = newInvoice;
-              // myboard.remain -= board.quantity;
-              await myboard.save();
+            users.map(async (user) => {
+              // console.log("user before", user);
+              user.myCards.delete(deletedName);
+              // console.log("user after", user);
+              await user.save();
             })
           );
+          console.log("user finish");
+          await Promise.all(
+            requests.map(async (request) => {
+              if (request.status !== "solved") {
+                // console.log("request before", request);
+                request.requestBody = request.requestBody.filter(
+                  (board) => board.board !== deletedName
+                );
+                // console.log("request after", request);
+              }
+              if (request.requestBody.length === 0) {
+                request.status = "cancel";
+                // const user = await model.TeamModel.findOne({
+                //   _id: request.borrower,
+                // });
+                // user.requests = user.requests.filter(
+                //   (id) => id !== request._id
+                // );
+                // await user.save();
+                // await model.RequestModel.deleteOne({
+                //   _id: request._id,
+                // });
+              }
+              await request.save();
+            })
+          );
+
+          broadcastPage("userProgress", ["AddBoard", boards]);
+          broadcast({ page: "adminBoardList" }, ["GETBOARD", boards]);
+          sendStatus(["success", "Delete successfully"], ws);
+          break;
+        }
+        case "GETBOARD": {
           const boards = await model.BoardModel.find({});
-          // console.log(boards);
+          // // console.log(boards);
+          sendData(["GETBOARD", boards], ws);
+          //sendStatus(["success", "Get successfully"], ws);
+          break;
         }
-        const requests = await model.RequestModel.find().populate(["borrower"]);
-        // sendData(["UPDATEREQUEST", requests], ws);
-        broadcast({ authority: 1, page: "requestStatus" }, [
-          "UPDATEREQUEST",
-          requests,
-        ]);
-        const userData = await model.TeamModel.findOne({
-          teamID: newReq.borrower.teamID,
-        }).populate(["requests"]);
-        broadcast(
-          { id: newReq.borrower.teamID, authority: 0, page: "userStatus" },
-          ["GETUSER", userData]
-        );
-        if (requestStatus === "solved") {
-          broadcast({ id: newReq.borrower.teamID }, [
-            "status",
-            ["success", "Boards have taken!!"],
+        case "GETREQUEST": {
+          //need populate
+          const requests = await model.RequestModel.find().populate([
+            "borrower",
           ]);
-        } // broadcast
-        if (requestStatus === "waiting") {
-          broadcast({ id: newReq.borrower.teamID }, [
-            "status",
-            ["success", "請確認是否領取", 8640000],
-          ]);
-        } // broadcast
-        if (requestStatus === "denied") {
-          broadcast({ id: newReq.borrower.teamID }, [
-            "status",
-            ["error", "Sorry Request Denied :("],
-          ]);
-          // broadcast({ id: newReq.borrower.teamID }, ["GETUSER", userData]);
-          changeBoardRemain(newReq);
-        } // broadcast
-        if (requestStatus === "cancel") {
-          changeBoardRemain(newReq);
-        } // broadcast
-        // sendStatus(["success", "Update successfully"], ws);
-        break;
-      }
-      case "UPDATERETURN": {
-        const { id, returned } = payload;
-        // console.log(id, returned);
-        const team = await model.TeamModel.findOne({ teamID: id }).populate([
-          "requests",
-        ]);
-        const teamsCard = JSON.parse(JSON.stringify(team.myCards));
-        // console.log(teamsCard);
-        for (const [key, value] of Object.entries(returned)) {
-          if (value === 0) continue;
-          teamsCard[key] -= value;
-          const myboard = await model.BoardModel.findOne({
-            name: key,
-          });
-          myboard.remain += value;
-          const newInvoice = myboard.invoice.map((item) => {
-            if (String(item.group) === String(team._id))
-              return { group: item.group, number: item.number - value };
-            else return item;
-          });
-          myboard.invoice = newInvoice.filter((item) => item.number > 0);
-          // // console.log(myboard.invoice);
-          await myboard.save();
-          // // console.log(myboard.invoice);
-          if (teamsCard[key] === 0) delete teamsCard[key];
+          // await requests..execPopulate();
+          // // console.log(requests);
+          sendData(["GETREQUEST", requests], ws);
+          // sendStatus(["success", "Get successfully"], ws);
+          break;
         }
-        team.myCards = teamsCard;
-        await team.save();
-        // // console.log(team.myCards);
-        const teams = await model.TeamModel.find({});
+        case "REQUEST": {
+          let { group, requestBody } = payload;
+          let gp = await model.TeamModel.findOne({ teamID: group });
+          let count = await model.RequestModel.countDocuments({
+            borrower: gp,
+          });
+          let boardMissing = false;
+          let numNotSatisfy = false;
+          await Promise.all(
+            requestBody.map(async (board) => {
+              const myboard = await model.BoardModel.findOne({
+                name: board[0],
+              });
+              if (!myboard) {
+                // console.log("Board missing:", board, myboard);
+                boardMissing = true;
+                return;
+              }
+              if (myboard.remain - board[1] < 0) {
+                numNotSatisfy = true;
+              }
+            })
+          );
+          if (numNotSatisfy) {
+            sendData(
+              [
+                "USERPROGRESSSTATUS",
+                [
+                  `Request Failed !`,
+                  `Some Boards are not enough for your request . Please Reselect Again!`,
+                ],
+              ],
+              ws
+            );
+            break;
+          }
+          if (boardMissing) {
+            sendData(
+              [
+                "USERPROGRESSSTATUS",
+                [
+                  `Request Failed !`,
+                  `Some Boards Missing. Please Refresh Page Again!`,
+                ],
+              ],
+              ws
+            );
+            break;
+          }
+          let body = requestBody.map((e) => {
+            return { board: e[0], quantity: e[1] };
+          });
 
-        broadcast({ id: id, authority: 0, page: "userStatus" }, [
-          "GETUSER",
-          team,
-        ]);
-        const boards = await model.BoardModel.find({});
+          const request = new model.RequestModel({
+            requestID: "Group" + group + "_request" + (count + 1),
+            borrower: gp,
+            sendingTime: new Date().getTime(),
+            status: "pending",
+            requestBody: body,
+          });
+          setTimeout(
+            () =>
+              requestExpired(
+                "Group" + group + "_request" + (count + 1),
+                "pending"
+              ),
+            15 * 60 * 1000
+          );
+          try {
+            await request.save();
+          } catch (e) {
+            // throw new Error("Request DB save error: " + e);
+            sendData(["USERPROGRESSSTATUS", [`Request Failed !`, `${e}`]], ws);
+          }
+          await model.TeamModel.updateMany(
+            { teamID: group },
+            { $push: { requests: request } }
+          );
+          const requests = await model.RequestModel.find().populate([
+            "borrower",
+          ]);
+          // // console.log(requests);
+          await Promise.all(
+            request.requestBody.map(async (board) => {
+              const myboard = await model.BoardModel.updateOne(
+                {
+                  name: board.board,
+                },
+                { $inc: { remain: -board.quantity } }
+              );
+              // myboard.remain -= board.quantity;
+            })
+          );
+          broadcastAuth(1, ["status", ["success", "New Request come in!"]]);
+          broadcast({ authority: 1, page: "requestStatus" }, [
+            "UPDATEREQUEST",
+            requests,
+          ]);
+          // sendStatus(["success", "Request successfully"], ws);
+          sendData(["USERPROGRESSSTATUS", [`Request successfully !`]], ws);
+          const boards = await model.BoardModel.find({});
+          broadcast({ page: "userProgress" }, ["INITUSERCARD", boards]);
+          broadcast({ page: "adminBoardList" }, ["GETBOARD", boards]);
 
-        broadcast({ page: "userProgress" }, ["AddBoard", boards]);
-        broadcast({ authority: 1, page: "requestStatus" }, [
-          "UPDATERETURN",
-          teams,
-        ]);
-        // sendData(["UPDATERETURN", teams], ws);
-        sendStatus(["success", "Update successfully"], ws);
-        break;
-      }
-      case "REPLACEBOARD": {
-        await model.BoardModel.deleteMany({});
-        await model.RequestModel.deleteMany({});
-        await model.TeamModel.updateMany(
-          { authority: 0 },
-          { $set: { myCards: {}, request: [] } }
-        );
+          let userData = await model.TeamModel.findOne({ teamID: group });
+          await userData.populate("requests").execPopulate();
+          broadcast({ id: group }, ["GETUSER", userData]);
+          break;
+        }
+        case "UPDATEREQ": {
+          const { requestID, requestStatus } = payload;
+          await model.RequestModel.updateOne(
+            { _id: requestID },
+            { $set: { status: requestStatus } }
+          );
+          const newReq = await model.RequestModel.findOne({
+            _id: requestID,
+          }).populate(["borrower"]);
+          // // console.log(newReq);
 
-        // console.log(payload);
-        const newBoards = await Promise.all(
-          payload.map(async (newBoard) => {
-            const saveBoard = await new model.BoardModel(newBoard).save();
-            return saveBoard;
-          })
-        );
-        // sendData(["GETBOARD", newBoards], ws);
-        broadcastPage("adminBoardList", ["GETBOARD", newBoards]);
-        broadcastPage("userProgress", ["AddBoard", newBoards]);
-        //sendStatus(["success", "Reset successfully"], ws);
-        break;
+          if (requestStatus === "ready") {
+            await model.RequestModel.updateOne(
+              { _id: requestID },
+              {
+                $set: {
+                  status: requestStatus,
+                  sendingTime: new Date().getTime(),
+                },
+              }
+            );
+            setTimeout(
+              () => requestExpired(newReq.requestID, "ready"),
+              15 * 60 * 1000
+            );
+            broadcast({ id: newReq.borrower.teamID }, [
+              "status",
+              ["success", "Request Ready!!", 8640000],
+            ]);
+          }
+          if (requestStatus === "solved") {
+            await updateMyCards(newReq.borrower.teamID, newReq.requestBody);
+            await Promise.all(
+              newReq.requestBody.map(async (board) => {
+                const myboard = await model.BoardModel.findOne({
+                  name: board.board,
+                });
+                let found = false;
+                let newInvoice = myboard.invoice.map((item) => {
+                  if (String(newReq.borrower._id) === String(item.group)) {
+                    found = true;
+                    return {
+                      group: item.group,
+                      number: item.number + board.quantity,
+                    };
+                  } else {
+                    return item;
+                  }
+                });
+                if (!found) {
+                  newInvoice = [
+                    ...myboard.invoice,
+                    { group: newReq.borrower._id, number: board.quantity },
+                  ];
+                }
+                // // console.log("newInvoice: ", board, newInvoice);
+                myboard.invoice = newInvoice;
+                // myboard.remain -= board.quantity;
+                await myboard.save();
+              })
+            );
+            const boards = await model.BoardModel.find({});
+            // console.log(boards);
+          }
+          const requests = await model.RequestModel.find().populate([
+            "borrower",
+          ]);
+          // sendData(["UPDATEREQUEST", requests], ws);
+          broadcast({ authority: 1, page: "requestStatus" }, [
+            "UPDATEREQUEST",
+            requests,
+          ]);
+          const userData = await model.TeamModel.findOne({
+            teamID: newReq.borrower.teamID,
+          }).populate(["requests"]);
+          broadcast(
+            { id: newReq.borrower.teamID, authority: 0, page: "userStatus" },
+            ["GETUSER", userData]
+          );
+          if (requestStatus === "solved") {
+            broadcast({ id: newReq.borrower.teamID }, [
+              "status",
+              ["success", "Boards have taken!!"],
+            ]);
+          } // broadcast
+          if (requestStatus === "waiting") {
+            broadcast({ id: newReq.borrower.teamID }, [
+              "status",
+              ["success", "請確認是否領取", 8640000],
+            ]);
+          } // broadcast
+          if (requestStatus === "denied") {
+            broadcast({ id: newReq.borrower.teamID }, [
+              "status",
+              ["error", "Sorry Request Denied :("],
+            ]);
+            // broadcast({ id: newReq.borrower.teamID }, ["GETUSER", userData]);
+            changeBoardRemain(newReq);
+          } // broadcast
+          if (requestStatus === "cancel") {
+            changeBoardRemain(newReq);
+          } // broadcast
+          // sendStatus(["success", "Update successfully"], ws);
+          break;
+        }
+        case "UPDATERETURN": {
+          const { id, returned } = payload;
+          // console.log(id, returned);
+          const team = await model.TeamModel.findOne({ teamID: id }).populate([
+            "requests",
+          ]);
+          const teamsCard = JSON.parse(JSON.stringify(team.myCards));
+          // console.log(teamsCard);
+          for (const [key, value] of Object.entries(returned)) {
+            if (value === 0) continue;
+            teamsCard[key] -= value;
+            const myboard = await model.BoardModel.findOne({
+              name: key,
+            });
+            myboard.remain += value;
+            const newInvoice = myboard.invoice.map((item) => {
+              if (String(item.group) === String(team._id))
+                return { group: item.group, number: item.number - value };
+              else return item;
+            });
+            myboard.invoice = newInvoice.filter((item) => item.number > 0);
+            // // console.log(myboard.invoice);
+            await myboard.save();
+            // // console.log(myboard.invoice);
+            if (teamsCard[key] === 0) delete teamsCard[key];
+          }
+          team.myCards = teamsCard;
+          await team.save();
+          // // console.log(team.myCards);
+          const teams = await model.TeamModel.find({});
+
+          broadcast({ id: id, authority: 0, page: "userStatus" }, [
+            "GETUSER",
+            team,
+          ]);
+          const boards = await model.BoardModel.find({});
+
+          broadcast({ page: "userProgress" }, ["AddBoard", boards]);
+          broadcast({ authority: 1, page: "requestStatus" }, [
+            "UPDATERETURN",
+            teams,
+          ]);
+          // sendData(["UPDATERETURN", teams], ws);
+          sendStatus(["success", "Update successfully"], ws);
+          break;
+        }
+        case "REPLACEBOARD": {
+          await model.BoardModel.deleteMany({});
+          await model.RequestModel.deleteMany({});
+          await model.TeamModel.updateMany(
+            { authority: 0 },
+            { $set: { myCards: {}, request: [] } }
+          );
+
+          // console.log(payload);
+          const newBoards = await Promise.all(
+            payload.map(async (newBoard) => {
+              const saveBoard = await new model.BoardModel(newBoard).save();
+              return saveBoard;
+            })
+          );
+          // sendData(["GETBOARD", newBoards], ws);
+          broadcastPage("adminBoardList", ["GETBOARD", newBoards]);
+          broadcastPage("userProgress", ["AddBoard", newBoards]);
+          //sendStatus(["success", "Reset successfully"], ws);
+          break;
+        }
+        case "BROADCASTANOUNCEMENT": {
+          const { task, msg, authority } = payload;
+          broadcastAuth(authority ?? 0, [
+            "ADMINANOUNCEMENT",
+            { task, msg, authority },
+          ]);
+          break;
+        }
       }
-      case "BROADCASTANOUNCEMENT": {
-        const { task, msg, authority } = payload;
-        broadcastAuth(authority ?? 0, [
-          "ADMINANOUNCEMENT",
-          { task, msg, authority },
-        ]);
-        break;
-      }
+    } catch (e) {
+      sendStatus(["error", "Request Failed"], ws);
+      console.log(
+        `ws of id:${ws.id},auth:${ws.authority},page:${ws.box} encounter error below:\n${e}`
+      );
     }
   },
   onClose: (ws) => async () => {

--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ import AdminBoardList from "./containers/adminBoardList";
 import RequestStatus from "./containers/requestStatus";
 import AdminLaserCutter from "./containers/admin_leichie";
 import LaserCutter from "./containers/user_leichie";
-
+import AdminAnounce from "./containers/adminAnnounce";
 import DP from "./containers/3dp";
 import theme from "./theme";
 // compononets
@@ -85,6 +85,7 @@ export default function App() {
     <div style={{ userSelect: "none" }}>
       <Router>
         <Drawer>
+          <AdminAnounce />
           <Routes />
         </Drawer>
       </Router>

--- a/src/components/adminCard.js
+++ b/src/components/adminCard.js
@@ -238,8 +238,15 @@ export default function ComplexGrid({
           top: 0,
           opacity: data?.remain !== data?.totalNum ? 0.7 : 1,
         }}
-        disabled={data?.remain !== data?.totalNum}
-        onClick={() => handleDeleteCard(data.id, data?.name || "Untitled")}
+        // disabled={data?.remain !== data?.totalNum}
+        onClick={() =>
+          handleDeleteCard(
+            data.id,
+            data.category,
+            data?.name || "Untitled",
+            data?.remain !== data?.totalNum
+          )
+        }
       >
         <CancelIcon />
       </ButtonBase>

--- a/src/components/adminCard.js
+++ b/src/components/adminCard.js
@@ -239,7 +239,7 @@ export default function ComplexGrid({
           opacity: data?.remain !== data?.totalNum ? 0.7 : 1,
         }}
         disabled={data?.remain !== data?.totalNum}
-        onClick={() => handleDeleteCard(data.id)}
+        onClick={() => handleDeleteCard(data.id, data?.name || "Untitled")}
       >
         <CancelIcon />
       </ButtonBase>

--- a/src/components/templateCard.js
+++ b/src/components/templateCard.js
@@ -8,6 +8,10 @@ import {
   TextField,
   IconButton,
   Box,
+  MenuItem,
+  Select,
+  InputLabel,
+  FormControl
 } from "@mui/material";
 import PropTypes from "prop-types";
 import { NumericFormat } from "react-number-format";
@@ -103,7 +107,7 @@ export default function ComplexGrid({ setAddCardData }) {
         margin: "5px",
         width: "20%",
         height: "auto",
-        maxHeight: "330px",
+        maxHeight: "360px",
         maxWidth: 230,
         minWidth: 150,
         flexGrow: 1,
@@ -170,7 +174,32 @@ export default function ComplexGrid({ setAddCardData }) {
             width: "100%",
           }}
         >
-          <TextField
+        <FormControl sx={{
+              width: "100%",
+              padding: "2px",
+              backgroundColor: "rgba(255,255,255,0.3)",
+              marginTop: "5px",
+              borderRadius: "10px",
+              borderWidth: "1rem",
+              borderColor: "#1d1d1d",
+              display: "flex",
+              justifyContent: "center"}}>
+        <InputLabel id="demo-simple-select-helper-label">category</InputLabel>
+        <Select
+          labelId="demo-simple-select-helper-label"
+          id="demo-simple-select-helper"
+          name="category"
+          value={values.category}
+          label="category"
+          onChange={handleChange}
+        >
+          <MenuItem value=""><em>None</em></MenuItem>
+          <MenuItem value="Tools">Tools</MenuItem>
+          <MenuItem value="Boards">Boards</MenuItem>
+          <MenuItem value="Modules">Modules</MenuItem>
+        </Select>
+        </FormControl>
+          {/* <TextField
             id="input-category"
             label="category"
             name="category"
@@ -207,7 +236,7 @@ export default function ComplexGrid({ setAddCardData }) {
               justifyContent: "center",
             }}
             // ref={nameInputRef}
-          />
+          /> */}
         </Grid>
         <Grid item>
           <IconButton

--- a/src/containers/adminAnnounce/index.js
+++ b/src/containers/adminAnnounce/index.js
@@ -7,12 +7,13 @@ import {
   DialogActions,
   Box,
   Button,
+  Typography,
 } from "@mui/material/";
 import { Redirect } from "react-router";
 import { selectSession } from "../../slices/sessionSlice";
 import { useMakeNTU } from "../../hooks/useMakeNTU";
 
-const Drawer = ({ children }) => {
+const Announcement = ({ children }) => {
   const { authority } = useSelector(selectSession);
   const dispatch = useDispatch();
   const { adminAnnounceOpen, setAdminAnnounceOpen, announcementMSG } =
@@ -30,7 +31,9 @@ const Drawer = ({ children }) => {
       <DialogTitle id="simple-dialog-title">管理員通知</DialogTitle>
       <DialogContent>
         <Box sx={{ minWidth: "15vw", minHeight: "10vh" }}>
-          {announcementMSG}
+          {announcementMSG.map((msg) => (
+            <Typography>{msg}</Typography>
+          ))}
         </Box>
       </DialogContent>
       <DialogActions>
@@ -41,4 +44,4 @@ const Drawer = ({ children }) => {
     </Dialog>
   );
 };
-export default Drawer;
+export default Announcement;

--- a/src/containers/adminAnnounce/index.js
+++ b/src/containers/adminAnnounce/index.js
@@ -1,0 +1,44 @@
+import React, { useState } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Box,
+  Button,
+} from "@mui/material/";
+import { Redirect } from "react-router";
+import { selectSession } from "../../slices/sessionSlice";
+import { useMakeNTU } from "../../hooks/useMakeNTU";
+
+const Drawer = ({ children }) => {
+  const { authority } = useSelector(selectSession);
+  const dispatch = useDispatch();
+  const { adminAnnounceOpen, setAdminAnnounceOpen, announcementMSG } =
+    useMakeNTU();
+
+  const handleAdminAnnounceClose = () => {
+    setAdminAnnounceOpen(false);
+  };
+  return (
+    <Dialog
+      aria-labelledby="simple-dialog-title"
+      open={authority !== 1 && adminAnnounceOpen}
+      onClose={handleAdminAnnounceClose}
+    >
+      <DialogTitle id="simple-dialog-title">管理員通知</DialogTitle>
+      <DialogContent>
+        <Box sx={{ minWidth: "15vw", minHeight: "10vh" }}>
+          {announcementMSG}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleAdminAnnounceClose} color="secondary">
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+export default Drawer;

--- a/src/containers/adminBoardList/BoardConsole.js
+++ b/src/containers/adminBoardList/BoardConsole.js
@@ -149,8 +149,11 @@ export default function BoardConsole({
     setCards(remainCards);
   }, [delCardID]);
 
-  const handleDeleteCard = (cardID, cardName) => {
-    const delMSG = `The Board ${cardName} has been deleted.`;
+  const handleDeleteCard = (cardID, cardCategory, cardName, changed) => {
+    const delMSG = [
+      `The ${cardCategory}: "${cardName}" has been deleted.`,
+      `Please Refresh Your Page.`,
+    ];
     setDelCardID(cardID);
     broadcastAnouncement({ task: "deletecard", msg: delMSG, toAuthority: 0 });
   };

--- a/src/containers/adminBoardList/BoardConsole.js
+++ b/src/containers/adminBoardList/BoardConsole.js
@@ -74,6 +74,7 @@ export default function BoardConsole({
     showAlert,
     setUpdateBoardStatus,
     subscribe,
+    broadcastAnouncement,
   } = useMakeNTU();
   const { teamID, authority } = useSelector(selectSession);
 
@@ -142,15 +143,17 @@ export default function BoardConsole({
   useEffect(() => {
     if (cards.length === 0) return;
     // const exist = cards.filter((card) => card.id === delCardID);
-    // // console.log(delCardID);
     deleteBoard(delCardID); // talk to server
     const remainCards = cards.filter((card) => card.id !== delCardID);
-
     setChangedData(changedData.filter((card) => card.id !== delCardID));
-    // // // console.log("deleting", exist);
     setCards(remainCards);
   }, [delCardID]);
 
+  const handleDeleteCard = (cardID, cardName) => {
+    const delMSG = `The Board ${cardName} has been deleted.`;
+    setDelCardID(cardID);
+    broadcastAnouncement({ task: "deletecard", msg: delMSG, toAuthority: 0 });
+  };
   const classes = useStyles();
   const { isLogin } = useSelector(selectSession);
   return (
@@ -185,7 +188,7 @@ export default function BoardConsole({
               <AdminCard
                 key={card?.name + card?.id}
                 data={card}
-                handleDeleteCard={setDelCardID}
+                handleDeleteCard={handleDeleteCard}
                 changedData={changedData}
                 setChangedData={setChangedData}
               ></AdminCard>

--- a/src/containers/adminBoardList/ConsoleHeader.js
+++ b/src/containers/adminBoardList/ConsoleHeader.js
@@ -307,7 +307,7 @@ export default function Header({ setSaving, ableSave, data }) {
           onClose={handleCloseReset}
           // sx={{ backgroundColor: "rgba(0,0,0,1)" }}
         >
-          <DialogTitle id="simple-dialog-title">Exporting Data</DialogTitle>
+          <DialogTitle id="simple-dialog-title">Reset</DialogTitle>
           <DialogContent>
             <Box sx={{ minWidth: "15vw", minHeight: "10vh" }}>
               {"Are you sure you want to RESET!? :("}

--- a/src/containers/requestStatus/components/RequestStatus.js
+++ b/src/containers/requestStatus/components/RequestStatus.js
@@ -63,6 +63,7 @@ function RequestStatus(props) {
     denied: "已拒絕",
     cancel: "已取消",
     expired: "已逾期",
+    waiting: "等待確認中",
   };
   return (
     <React.Fragment>

--- a/src/containers/requestStatus/components/RequestStatusContent.js
+++ b/src/containers/requestStatus/components/RequestStatusContent.js
@@ -38,8 +38,8 @@ const GroupStatusContent = (props) => {
       // console.log("missing requestID: ", data?._id);
       return;
     }
-    updateReq({ requestID: data?._id, requestStatus: "solved" });
-    deleteRequestFromUser([data.borrower.teamID, data?._id]);
+    updateReq({ requestID: data?._id, requestStatus: "waiting" });
+    // deleteRequestFromUser([data.borrower.teamID, data?._id]);
   };
   return (
     <TableCell style={{ paddingBottom: 0, paddingTop: 0 }} colSpan={6}>

--- a/src/containers/userStatus/UserRow.js
+++ b/src/containers/userStatus/UserRow.js
@@ -76,6 +76,13 @@ function Row(props) {
           <TableCell align="left" sx={{ border: 0, minWidth: "4em", p: "6px" }}>
             請來拿
           </TableCell>
+        ) : row.status === "waiting" ? (
+          <TableCell
+            align="left"
+            sx={{ color: "#00FF00", border: 0, minWidth: "4em", p: "6px" }}
+          >
+            請確認
+          </TableCell>
         ) : (
           <TableCell
             align="left"

--- a/src/containers/userStatus/UserRowContent.js
+++ b/src/containers/userStatus/UserRowContent.js
@@ -13,10 +13,20 @@ import { useMakeNTU } from "../../hooks/useMakeNTU";
 const rowContent = (props) => {
   const { row, open, teamID, state } = props;
   const [alertOpen, setAlertOpen] = React.useState(false);
-  const { cancelRequest, breakpoints } = useMakeNTU();
-  const handleClick = () => {
+  const { cancelRequest, breakpoints, updateReq, deleteRequestFromUser } =
+    useMakeNTU();
+  const handleCancel = () => {
     setAlertOpen(true);
   };
+  const handleConfirm = () => {
+    if (!row?._id) {
+      // console.log("missing requestID: ", data?._id);
+      return;
+    }
+    updateReq({ requestID: row?._id, requestStatus: "solved" });
+    deleteRequestFromUser([teamID, row?._id]);
+  };
+
   const handleAlertClose = () => {
     setAlertOpen(false);
   };
@@ -68,7 +78,16 @@ const rowContent = (props) => {
           {state ? (
             <></>
           ) : row.status === "pending" ? (
-            <Chip label="Cancel" variant="outlined" onClick={handleClick} />
+            <Chip label="Cancel" variant="outlined" onClick={handleCancel} />
+          ) : row.status === "waiting" ? (
+            <>
+              <Chip
+                label="Confirm"
+                variant="outlined"
+                onClick={handleConfirm}
+              />
+              <Chip label="Cancel" variant="outlined" onClick={handleCancel} />
+            </>
           ) : (
             <></>
           )}

--- a/src/hooks/useMakeNTU.js
+++ b/src/hooks/useMakeNTU.js
@@ -85,8 +85,8 @@ const MakeNTUProvider = (props) => {
         break;
       }
       case "status": {
-        const [msgStatus, msg] = payload;
-        showAlert(msgStatus, msg);
+        const [msgStatus, msg, duration] = payload;
+        showAlert(msgStatus, msg, duration);
         //setStatus(payload);
         break;
       }

--- a/src/hooks/useMakeNTU.js
+++ b/src/hooks/useMakeNTU.js
@@ -47,7 +47,7 @@ const MakeNTUContext = React.createContext({
   resetDataBase: () => {},
   adminAnnounceOpen: false,
   setAdminAnnounceOpen: () => {},
-  announcementMSG: "",
+  announcementMSG: [],
   broadcastAnouncement: () => {},
 });
 
@@ -64,7 +64,7 @@ const MakeNTUProvider = (props) => {
   const [render, setRender] = React.useState(false);
   const [userProgressStatus, setUserProgressStatus] = React.useState([]);
   const [adminAnnounceOpen, setAdminAnnounceOpen] = React.useState(false);
-  const [announcementMSG, setAnnouncementMSG] = React.useState("");
+  const [announcementMSG, setAnnouncementMSG] = React.useState([]);
   const breakpoints = useBreakpoints();
 
   client.onmessage = async (byteString) => {

--- a/src/hooks/useMakeNTU.js
+++ b/src/hooks/useMakeNTU.js
@@ -1,6 +1,7 @@
 // const React = require("react");
 
 //import { useState, createContext, useContext, useEffect } from "react";
+import { bool } from "prop-types";
 import React from "react";
 import { v4 as uuidv4 } from "uuid";
 import useBreakpoints from "./useBreakpoints";
@@ -40,10 +41,14 @@ const MakeNTUContext = React.createContext({
   cancelRequest: () => {},
   deleteRequestFromUser: () => {},
   subscribe: () => {},
-  render: [],
+  render: false,
   setRender: () => {},
   userProgressStatus: [],
   resetDataBase: () => {},
+  adminAnnounceOpen: false,
+  setAdminAnnounceOpen: () => {},
+  announcementMSG: "",
+  broadcastAnouncement: () => {},
 });
 
 const MakeNTUProvider = (props) => {
@@ -58,6 +63,8 @@ const MakeNTUProvider = (props) => {
   const [userRequest, setUserRequest] = React.useState([]);
   const [render, setRender] = React.useState(false);
   const [userProgressStatus, setUserProgressStatus] = React.useState([]);
+  const [adminAnnounceOpen, setAdminAnnounceOpen] = React.useState(false);
+  const [announcementMSG, setAnnouncementMSG] = React.useState("");
   const breakpoints = useBreakpoints();
 
   client.onmessage = async (byteString) => {
@@ -114,6 +121,10 @@ const MakeNTUProvider = (props) => {
       case "UPDATERETURN": {
         setTeamReqUpdateDate(payload);
         break;
+      }
+      case "ADMINANOUNCEMENT": {
+        setAnnouncementMSG(payload?.msg ?? "");
+        setAdminAnnounceOpen(true);
       }
       default:
         break;
@@ -251,6 +262,9 @@ const MakeNTUProvider = (props) => {
   const resetDataBase = () => {
     sendData(["RESETDATABASE"]);
   };
+  const broadcastAnouncement = (payload) => {
+    sendData(["BROADCASTANOUNCEMENT", payload]);
+  };
   return (
     <MakeNTUContext.Provider
       value={{
@@ -287,6 +301,10 @@ const MakeNTUProvider = (props) => {
         setRender,
         userProgressStatus,
         resetDataBase,
+        adminAnnounceOpen,
+        setAdminAnnounceOpen,
+        announcementMSG,
+        broadcastAnouncement,
       }}
       {...props}
     />


### PR DESCRIPTION
- [X] -Tag(類別)目前用填空式 ⇒ 可以用選單式
- [X] Admin刪除板子可以送個通知給所有user
    - [X] ws 寫一個監聽admin announcement的東西
    - 寫了一個adminAnnounce 的page 可以用 broadcastAnouncement({ task, msg, toAuthority })發送訊息
    - 目前Announcement page 僅有一個關閉按鈕
- 呼叫後取消可以不用直接刪掉訂單
   - 目前沒有刪掉訂單，只是跑到**已取消**的分類裡
- [X] 呼叫的提醒列不要自動消失，要確保team有收到訊息
   - duration 設成8640000ms 即一天，使用者須點擊頁面通知才會消失
- [X] **已領取**要雙方(team & admin)皆按同意才能拉過去
   - 新增waiting狀態
- 歸還部分感覺沒有必要